### PR TITLE
feat: Add a new variable to control the creation of a lifecycle policy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_create"></a> [create](#input\_create) | Determines whether resources will be created (affects all resources) | `bool` | `true` | no |
-| <a name="input_create_lifecycle_policy"></a> [create\_lifecycle\_policy](#input\_create\_lifecycle\_policy) | Determines whether a lifecycle policy will be created | `bool` | `false` | no |
+| <a name="input_create_lifecycle_policy"></a> [create\_lifecycle\_policy](#input\_create\_lifecycle\_policy) | Determines whether a lifecycle policy will be created | `bool` | `true` | no |
 | <a name="input_create_registry_policy"></a> [create\_registry\_policy](#input\_create\_registry\_policy) | Determines whether a registry policy will be created | `bool` | `false` | no |
 | <a name="input_create_registry_replication_configuration"></a> [create\_registry\_replication\_configuration](#input\_create\_registry\_replication\_configuration) | Determines whether a registry replication configuration will be created | `bool` | `false` | no |
 | <a name="input_create_repository"></a> [create\_repository](#input\_create\_repository) | Determines whether a repository will be created | `bool` | `true` | no |

--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_create"></a> [create](#input\_create) | Determines whether resources will be created (affects all resources) | `bool` | `true` | no |
+| <a name="input_create_lifecycle_policy"></a> [create\_lifecycle\_policy](#input\_create\_lifecycle\_policy) | Determines whether a lifecycle policy will be created | `bool` | `false` | no |
 | <a name="input_create_registry_policy"></a> [create\_registry\_policy](#input\_create\_registry\_policy) | Determines whether a registry policy will be created | `bool` | `false` | no |
 | <a name="input_create_registry_replication_configuration"></a> [create\_registry\_replication\_configuration](#input\_create\_registry\_replication\_configuration) | Determines whether a registry replication configuration will be created | `bool` | `false` | no |
 | <a name="input_create_repository"></a> [create\_repository](#input\_create\_repository) | Determines whether a repository will be created | `bool` | `true` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -32,6 +32,7 @@ module "ecr" {
   repository_name = local.name
 
   repository_read_write_access_arns = [data.aws_caller_identity.current.arn]
+  create_lifecycle_policy           = true
   repository_lifecycle_policy = jsonencode({
     rules = [
       {

--- a/main.tf
+++ b/main.tf
@@ -120,7 +120,7 @@ resource "aws_ecr_repository_policy" "this" {
 ################################################################################
 
 resource "aws_ecr_lifecycle_policy" "this" {
-  count = local.create_private_repository ? 1 : 0
+  count = local.create_private_repository && var.create_lifecycle_policy ? 1 : 0
 
   repository = aws_ecr_repository.this[0].name
   policy     = var.repository_lifecycle_policy

--- a/main.tf
+++ b/main.tf
@@ -109,7 +109,7 @@ resource "aws_ecr_repository" "this" {
 ################################################################################
 
 resource "aws_ecr_repository_policy" "this" {
-  count = local.create_private_repository ? 1 : 0
+  count = local.create_private_repository && var.create_repository_policy ? 1 : 0
 
   repository = aws_ecr_repository.this[0].name
   policy     = var.create_repository_policy ? data.aws_iam_policy_document.repository[0].json : var.repository_policy

--- a/variables.tf
+++ b/variables.tf
@@ -91,7 +91,7 @@ variable "repository_read_write_access_arns" {
 variable "create_lifecycle_policy" {
   description = "Determines whether a lifecycle policy will be created"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "repository_lifecycle_policy" {

--- a/variables.tf
+++ b/variables.tf
@@ -88,6 +88,12 @@ variable "repository_read_write_access_arns" {
 # Lifecycle Policy
 ################################################################################
 
+variable "create_lifecycle_policy" {
+  description = "Determines whether a lifecycle policy will be created"
+  type        = bool
+  default     = false
+}
+
 variable "repository_lifecycle_policy" {
   description = "The policy document. This is a JSON formatted string. See more details about [Policy Parameters](http://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html#lifecycle_policy_parameters) in the official AWS docs"
   type        = string

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -16,7 +16,7 @@ module "wrapper" {
   create_repository_policy                  = try(each.value.create_repository_policy, var.defaults.create_repository_policy, true)
   repository_read_access_arns               = try(each.value.repository_read_access_arns, var.defaults.repository_read_access_arns, [])
   repository_read_write_access_arns         = try(each.value.repository_read_write_access_arns, var.defaults.repository_read_write_access_arns, [])
-  create_lifecycle_policy                   = try(each.value.create_lifecycle_policy, var.defaults.create_lifecycle_policy, false)
+  create_lifecycle_policy                   = try(each.value.create_lifecycle_policy, var.defaults.create_lifecycle_policy, true)
   repository_lifecycle_policy               = try(each.value.repository_lifecycle_policy, var.defaults.repository_lifecycle_policy, "")
   public_repository_catalog_data            = try(each.value.public_repository_catalog_data, var.defaults.public_repository_catalog_data, {})
   create_registry_policy                    = try(each.value.create_registry_policy, var.defaults.create_registry_policy, false)

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -16,6 +16,7 @@ module "wrapper" {
   create_repository_policy                  = try(each.value.create_repository_policy, var.defaults.create_repository_policy, true)
   repository_read_access_arns               = try(each.value.repository_read_access_arns, var.defaults.repository_read_access_arns, [])
   repository_read_write_access_arns         = try(each.value.repository_read_write_access_arns, var.defaults.repository_read_write_access_arns, [])
+  create_lifecycle_policy                   = try(each.value.create_lifecycle_policy, var.defaults.create_lifecycle_policy, false)
   repository_lifecycle_policy               = try(each.value.repository_lifecycle_policy, var.defaults.repository_lifecycle_policy, "")
   public_repository_catalog_data            = try(each.value.public_repository_catalog_data, var.defaults.public_repository_catalog_data, {})
   create_registry_policy                    = try(each.value.create_registry_policy, var.defaults.create_registry_policy, false)


### PR DESCRIPTION
## Description
- This pull request adds a new variable that determines whether a lifecycle policy is created. The previous default behaviour was to always create a lifecycle policy. If you didn't want a lifecycle policy, there was no way to do this. You will now have to set `create_lifecycle_policy` to `true` if you want a lifecycle policy to be created.
- Add missing usage of `create_repository_policy` variable to policy creation

## Motivation and Context
Sometimes a lifecycle policy isn't needed or wanted. This fixes https://github.com/terraform-aws-modules/terraform-aws-ecr/issues/2 
Closes #5

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
I wouldn't call this a breaking change. However, users who do want to have a lifecycle policy created will need to add the new variable to ensure that it is created.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

I have tested using the complete example by setting `create_lifecycle_policy` to both `true` and `false`. I've also updated this example to ensure that the lifecycle policy is created in future.

I also tested this using the reproduction code from https://github.com/terraform-aws-modules/terraform-aws-ecr/issues/2
