### PR TITLE
fix: Do not create a repository policy when the create_repository_policy variable is false

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -109,7 +109,7 @@ resource "aws_ecr_repository" "this" {
 ################################################################################
 
 resource "aws_ecr_repository_policy" "this" {
-  count = local.create_private_repository ? 1 : 0
+  count = local.create_private_repository && var.create_repository_policy ? 1 : 0
 
   repository = aws_ecr_repository.this[0].name
   policy     = var.create_repository_policy ? data.aws_iam_policy_document.repository[0].json : var.repository_policy


### PR DESCRIPTION
## Description
If `create_repository_policy` is set to `false` the module still tries to create the `aws_ecr_repository_policy.this[0]` resource. This PR fixes this so that when this variable is set to false this resource is no longer created.

One question I have is whether `create_repository_policy` should default to `false`? When creating an ECR repository in the console, you do not automatically get a repository policy. I thought about including this change in this PR but thought I would get feedback first. Apologies if this is not the correct place to discuss this. Should I open an issue for this discussion?

## Motivation and Context
This change is required to fix the expected behaviour.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
This is not a breaking change

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
