### PR TITLE
fix: Add new variable to control whether a repository policy is attached to the repository

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.72.1
+    rev: v1.72.2
     hooks:
       - id: terraform_fmt
       - id: terraform_wrapper_module_for_each

--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_attach_repository_policy"></a> [attach\_repository\_policy](#input\_attach\_repository\_policy) | Determines whether a repository policy will be attached to the repository | `bool` | `true` | no |
 | <a name="input_create"></a> [create](#input\_create) | Determines whether resources will be created (affects all resources) | `bool` | `true` | no |
 | <a name="input_create_lifecycle_policy"></a> [create\_lifecycle\_policy](#input\_create\_lifecycle\_policy) | Determines whether a lifecycle policy will be created | `bool` | `true` | no |
 | <a name="input_create_registry_policy"></a> [create\_registry\_policy](#input\_create\_registry\_policy) | Determines whether a registry policy will be created | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -109,7 +109,7 @@ resource "aws_ecr_repository" "this" {
 ################################################################################
 
 resource "aws_ecr_repository_policy" "this" {
-  count = local.create_private_repository && var.create_repository_policy ? 1 : 0
+  count = local.create_private_repository && var.attach_repository_policy ? 1 : 0
 
   repository = aws_ecr_repository.this[0].name
   policy     = var.create_repository_policy ? data.aws_iam_policy_document.repository[0].json : var.repository_policy

--- a/variables.tf
+++ b/variables.tf
@@ -66,6 +66,12 @@ variable "repository_policy" {
 # Repository Policy
 ################################################################################
 
+variable "attach_repository_policy" {
+  description = "Determines whether a repository policy will be attached to the repository"
+  type        = bool
+  default     = true
+}
+
 variable "create_repository_policy" {
   description = "Determines whether a repository policy will be created"
   type        = bool

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -13,6 +13,7 @@ module "wrapper" {
   repository_kms_key                        = try(each.value.repository_kms_key, var.defaults.repository_kms_key, null)
   repository_image_scan_on_push             = try(each.value.repository_image_scan_on_push, var.defaults.repository_image_scan_on_push, true)
   repository_policy                         = try(each.value.repository_policy, var.defaults.repository_policy, null)
+  attach_repository_policy                  = try(each.value.attach_repository_policy, var.defaults.attach_repository_policy, true)
   create_repository_policy                  = try(each.value.create_repository_policy, var.defaults.create_repository_policy, true)
   repository_read_access_arns               = try(each.value.repository_read_access_arns, var.defaults.repository_read_access_arns, [])
   repository_read_write_access_arns         = try(each.value.repository_read_write_access_arns, var.defaults.repository_read_write_access_arns, [])


### PR DESCRIPTION
## Description
- Add new variable to control whether a repository policy is attached to the repository

## Motivation and Context
- Closes #6 - users can now let the module create a policy, bring their own, or not attach a policy to the repository at all

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
