### PR TITLE
fix: Use the custom repository policy when create_repository_policy is true

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -135,7 +135,7 @@ resource "aws_ecr_repository_policy" "this" {
   count = local.create_private_repository && var.attach_repository_policy ? 1 : 0
 
   repository = aws_ecr_repository.this[0].name
-  policy     = var.create_repository_policy ? data.aws_iam_policy_document.repository[0].json : var.repository_policy
+  policy     = var.create_repository_policy ? var.repository_policy : data.aws_iam_policy_document.repository[0].json
 }
 
 ################################################################################


### PR DESCRIPTION
## Description

Create repository policy flag when will be set to true will use a custom policy passed to module instead of default one.



## Motivation and Context
I find this disturbing when I set the create_repository_policy to true and my custom policy was ignored and I still have a default one.  I think this condition should have a different order, so when I set the create_policy_argument true then module should use my custom policy.

## How Has This Been Tested?
Locally in my terragrunt module.
