### PR TITLE
feat: Added ecr:GetAuthorizationToken for private ECR with Docker capabilities

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -46,6 +46,7 @@ data "aws_iam_policy_document" "repository" {
       }
 
       actions = [
+        "ecr:GetAuthorizationToken",
         "ecr:BatchCheckLayerAvailability",
         "ecr:BatchGetImage",
         "ecr:DescribeImageScanFindings",


### PR DESCRIPTION
Fixed private ECR policy to allow Docker capabilities.
 Could be improved with an input variable for docker_capability activation.

## Description
Added ecr:GetAuthorizationToken policy for private ECR with Docker capabilities

## Motivation and Context
Using the ECR as private with as Docker (OCI) registry.

## Breaking Changes
Adds a not needed policy for the private ECR when not used for Docker.

## How Has This Been Tested?
Ongoing
