### PR TITLE
[fix] Rename ecrpublic registry policy resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -204,7 +204,7 @@ resource "aws_ecrpublic_repository" "this" {
 # Public Repository Policy
 ################################################################################
 
-resource "aws_ecrpublic_repository_policy" "example" {
+resource "aws_ecrpublic_repository_policy" "this" {
   count = local.create_public_repository ? 1 : 0
 
   repository_name = aws_ecrpublic_repository.this[0].repository_name


### PR DESCRIPTION
## Description
Fix a mistake in resource naming
<!--- Describe your changes in detail -->

## Motivation and Context
Consistency and my OCD
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
It will cause a delete and create action for users with public repositories deployed. If they happen in the wrong order the policy may be deleted after it is applied. Users would need to apply a second time to ensure their infra is consistent with code.
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
