### PR TITLE
feat!: Allow multiple scan filters per scan type in registry; Raise MSV of Terraform and AWS provider to 1.0 and 5.0 respectively

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.88.0
+    rev: v1.88.2
     hooks:
       - id: terraform_fmt
       - id: terraform_wrapper_module_for_each

--- a/README.md
+++ b/README.md
@@ -129,12 +129,23 @@ module "ecr_registry" {
   registry_scan_rules = [
     {
       scan_frequency = "SCAN_ON_PUSH"
-      filter         = "*"
-      filter_type    = "WILDCARD"
-      }, {
+      filters = [
+        {
+          filter      = "example1"
+          filter_type = "WILDCARD"
+        },
+        { filter      = "example2"
+          filter_type = "WILDCARD"
+        }
+      ]
+    }, {
       scan_frequency = "CONTINUOUS_SCAN"
-      filter         = "example"
-      filter_type    = "WILDCARD"
+      filters = [
+        {
+          filter      = "example"
+          filter_type = "WILDCARD"
+        }
+      ]
     }
   ]
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ module "ecr_registry" {
   registry_scan_rules = [
     {
       scan_frequency = "SCAN_ON_PUSH"
-      filters = [
+      filter = [
         {
           filter      = "example1"
           filter_type = "WILDCARD"
@@ -140,7 +140,7 @@ module "ecr_registry" {
       ]
     }, {
       scan_frequency = "CONTINUOUS_SCAN"
-      filters = [
+      filter = [
         {
           filter      = "example"
           filter_type = "WILDCARD"
@@ -192,14 +192,14 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.22 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.22 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -27,14 +27,14 @@ Note that this example may create resources which will incur monetary charges on
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.22 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.22 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -137,7 +137,7 @@ module "ecr_registry" {
   registry_scan_rules = [
     {
       scan_frequency = "SCAN_ON_PUSH"
-      filters = [
+      filter = [
         {
           filter      = "example1"
           filter_type = "WILDCARD"
@@ -148,7 +148,7 @@ module "ecr_registry" {
       ]
       }, {
       scan_frequency = "CONTINUOUS_SCAN"
-      filters = [
+      filter = [
         {
           filter      = "example"
           filter_type = "WILDCARD"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -137,12 +137,23 @@ module "ecr_registry" {
   registry_scan_rules = [
     {
       scan_frequency = "SCAN_ON_PUSH"
-      filter         = "*"
-      filter_type    = "WILDCARD"
+      filters = [
+        {
+          filter      = "example1"
+          filter_type = "WILDCARD"
+        },
+        { filter      = "example2"
+          filter_type = "WILDCARD"
+        }
+      ]
       }, {
       scan_frequency = "CONTINUOUS_SCAN"
-      filter         = "example"
-      filter_type    = "WILDCARD"
+      filters = [
+        {
+          filter      = "example"
+          filter_type = "WILDCARD"
+        }
+      ]
     }
   ]
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.22"
+      version = ">= 5.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -287,9 +287,13 @@ resource "aws_ecr_registry_scanning_configuration" "this" {
     content {
       scan_frequency = rule.value.scan_frequency
 
-      repository_filter {
-        filter      = rule.value.filter
-        filter_type = try(rule.value.filter_type, "WILDCARD")
+      dynamic "repository_filter" {
+        for_each = rule.value.filters
+
+        content {
+          filter      = repository_filter.value.filter
+          filter_type = try(repository_filter.value.filter_type, "WILDCARD")
+        }
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -288,7 +288,7 @@ resource "aws_ecr_registry_scanning_configuration" "this" {
       scan_frequency = rule.value.scan_frequency
 
       dynamic "repository_filter" {
-        for_each = rule.value.filters
+        for_each = rule.value.filter
 
         content {
           filter      = repository_filter.value.filter

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.22"
+      version = ">= 5.0"
     }
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Increase the functionality of AWS ECR registry scan rules by implementing the capability to accommodate multiple scan filters per scan type, thereby enhancing the flexibility and customization options available for users.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This feature became essential during my work on a project where there was a requirement to incorporate multiple filters into the scaling configuration. However, this couldn't be accomplished with the existing implementation.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
Yes, 'filter' parameter under 'registry_scan_rules,' which has now been renamed to 'filters,' and its data type has been altered from a string to an array of maps. Consequently, users relying on the existing implementation must update their 'registry_scan_rules' configuration to align with these changes in order to effectively utilize the updated features.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
