### PR TITLE
feat: Add `credentials_arn` to support ECR pull through cache

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.88.2
+    rev: v1.88.3
     hooks:
       - id: terraform_fmt
       - id: terraform_wrapper_module_for_each

--- a/README.md
+++ b/README.md
@@ -111,6 +111,19 @@ module "ecr_registry" {
         Resource = [
           "arn:aws:ecr:us-east-1:012345678901:repository/*"
         ]
+      }, {
+        Sid    = "dockerhub",
+        Effect = "Allow",
+        Principal = {
+          "AWS" : "arn:aws:iam::012345678901:root"
+        },
+        Action = [
+          "ecr:CreateRepository",
+          "ecr:BatchImportUpstreamImage"
+        ],
+        Resource = [
+          "arn:aws:ecr:us-east-1:012345678901:repository/dockerhub/*"
+        ]
       }
     ]
   })
@@ -124,8 +137,9 @@ module "ecr_registry" {
     dockerhub = {
       ecr_repository_prefix = "dockerhub"
       upstream_registry_url = "registry-1.docker.io"
+      
       # Make sure to read https://docs.aws.amazon.com/AmazonECR/latest/userguide/pull-through-cache-creating-secret.html
-      credential_arn        = "arn:aws:secretsmanager:us-east-1:123456789:secret:ecr-pullthroughcache/dockerhub"
+      credential_arn = "arn:aws:secretsmanager:us-east-1:123456789:secret:ecr-pullthroughcache/dockerhub"
     }
   }
 

--- a/README.md
+++ b/README.md
@@ -137,8 +137,7 @@ module "ecr_registry" {
     dockerhub = {
       ecr_repository_prefix = "dockerhub"
       upstream_registry_url = "registry-1.docker.io"
-      # Make sure to read https://docs.aws.amazon.com/AmazonECR/latest/userguide/pull-through-cache-creating-secret.html
-      credential_arn = "arn:aws:secretsmanager:us-east-1:123456789:secret:ecr-pullthroughcache/dockerhub"
+      credential_arn        = "arn:aws:secretsmanager:us-east-1:123456789:secret:ecr-pullthroughcache/dockerhub"
     }
   }
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,6 @@ module "ecr_registry" {
     dockerhub = {
       ecr_repository_prefix = "dockerhub"
       upstream_registry_url = "registry-1.docker.io"
-      
       # Make sure to read https://docs.aws.amazon.com/AmazonECR/latest/userguide/pull-through-cache-creating-secret.html
       credential_arn = "arn:aws:secretsmanager:us-east-1:123456789:secret:ecr-pullthroughcache/dockerhub"
     }

--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ module "ecr_registry" {
       ecr_repository_prefix = "ecr-public"
       upstream_registry_url = "public.ecr.aws"
     }
+    dockerhub = {
+      ecr_repository_prefix = "dockerhub"
+      upstream_registry_url = "registry-1.docker.io"
+      # Make sure to read https://docs.aws.amazon.com/AmazonECR/latest/userguide/pull-through-cache-creating-secret.html
+      credential_arn        = "arn:aws:secretsmanager:us-east-1:123456789:secret:ecr-pullthroughcache/dockerhub"
+    }
   }
 
   # Registry Scanning Configuration

--- a/README.md
+++ b/README.md
@@ -202,13 +202,13 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.22 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.37 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.22 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.37 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -40,6 +40,7 @@ Note that this example may create resources which will incur monetary charges on
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_dockerhub_credentials"></a> [dockerhub\_credentials](#module\_dockerhub\_credentials) | terraform-aws-modules/secrets-manager/aws | n/a |
 | <a name="module_ecr"></a> [ecr](#module\_ecr) | ../.. | n/a |
 | <a name="module_ecr_disabled"></a> [ecr\_disabled](#module\_ecr\_disabled) | ../.. | n/a |
 | <a name="module_ecr_registry"></a> [ecr\_registry](#module\_ecr\_registry) | ../.. | n/a |
@@ -52,10 +53,13 @@ Note that this example may create resources which will incur monetary charges on
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.registry](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_dockerhub_credentials"></a> [dockerhub\_credentials](#input\_dockerhub\_credentials) | Dockerhub credentials | <pre>object({<br>    username    = string<br>    accessToken = string<br>  })</pre> | n/a | yes |
 
 ## Outputs
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -40,11 +40,11 @@ Note that this example may create resources which will incur monetary charges on
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_dockerhub_credentials"></a> [dockerhub\_credentials](#module\_dockerhub\_credentials) | terraform-aws-modules/secrets-manager/aws | n/a |
 | <a name="module_ecr"></a> [ecr](#module\_ecr) | ../.. | n/a |
 | <a name="module_ecr_disabled"></a> [ecr\_disabled](#module\_ecr\_disabled) | ../.. | n/a |
 | <a name="module_ecr_registry"></a> [ecr\_registry](#module\_ecr\_registry) | ../.. | n/a |
 | <a name="module_public_ecr"></a> [public\_ecr](#module\_public\_ecr) | ../.. | n/a |
+| <a name="module_secrets_manager_dockerhub_credentials"></a> [secrets\_manager\_dockerhub\_credentials](#module\_secrets\_manager\_dockerhub\_credentials) | terraform-aws-modules/secrets-manager/aws | ~> 1.0 |
 
 ## Resources
 
@@ -52,14 +52,10 @@ Note that this example may create resources which will incur monetary charges on
 |------|------|
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.registry](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_dockerhub_credentials"></a> [dockerhub\_credentials](#input\_dockerhub\_credentials) | Dockerhub credentials | <pre>object({<br>    username    = string<br>    accessToken = string<br>  })</pre> | n/a | yes |
+No inputs.
 
 ## Outputs
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -28,13 +28,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.22 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.37 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.22 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.37 |
 
 ## Modules
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -153,7 +153,7 @@ module "ecr_registry" {
       ecr_repository_prefix = "dockerhub"
       upstream_registry_url = "registry-1.docker.io"
       # Make sure to read https://docs.aws.amazon.com/AmazonECR/latest/userguide/pull-through-cache-creating-secret.html
-      credential_arn        = "arn:aws:secretsmanager:us-east-1:123456789:secret:ecr-pullthroughcache/dockerhub"
+      credential_arn = "arn:aws:secretsmanager:us-east-1:123456789:secret:ecr-pullthroughcache/dockerhub"
     }
   }
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -175,15 +175,13 @@ module "ecr_registry" {
   # Registry Replication Configuration
   create_registry_replication_configuration = true
   registry_replication_rules = [{
-    destinations = [
-      {
-        region      = "us-west-2"
-        registry_id = local.account_id
-        }, {
-        region      = "eu-west-1"
-        registry_id = local.account_id
-      }
-    ]
+    destinations = [{
+      region      = "us-west-2"
+      registry_id = local.account_id
+      }, {
+      region      = "eu-west-1"
+      registry_id = local.account_id
+    }]
 
     repository_filters = [{
       filter      = "prod-microservice"
@@ -215,12 +213,10 @@ module "secrets_manager_dockerhub_credentials" {
   policy_statements = {
     read = {
       sid = "AllowAccountRead"
-      principals = [
-        {
-          type        = "AWS"
-          identifiers = ["arn:aws:iam::${local.account_id}:root"]
-        }
-      ]
+      principals = [{
+        type        = "AWS"
+        identifiers = ["arn:aws:iam::${local.account_id}:root"]
+      }]
       actions   = ["secretsmanager:GetSecretValue"]
       resources = ["*"]
     }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -152,9 +152,8 @@ module "ecr_registry" {
     dockerhub = {
       ecr_repository_prefix = "dockerhub"
       upstream_registry_url = "registry-1.docker.io"
-
       # Make sure to read https://docs.aws.amazon.com/AmazonECR/latest/userguide/pull-through-cache-creating-secret.html
-      credential_arn = "arn:aws:secretsmanager:us-east-1:123456789:secret:ecr-pullthroughcache/dockerhub"
+      credential_arn        = "arn:aws:secretsmanager:us-east-1:123456789:secret:ecr-pullthroughcache/dockerhub"
     }
   }
 

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -1,0 +1,8 @@
+variable "dockerhub_credentials" {
+  type = object({
+    username    = string
+    accessToken = string
+  })
+  description = "Dockerhub credentials"
+  sensitive   = true
+}

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -1,8 +1,0 @@
-variable "dockerhub_credentials" {
-  type = object({
-    username    = string
-    accessToken = string
-  })
-  description = "Dockerhub credentials"
-  sensitive   = true
-}

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.22"
+      version = ">= 5.37"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -270,7 +270,7 @@ resource "aws_ecr_pull_through_cache_rule" "this" {
 
   ecr_repository_prefix = each.value.ecr_repository_prefix
   upstream_registry_url = each.value.upstream_registry_url
-  credential_arn        = coalesce(each.value.credential_arn, null)
+  credential_arn        = lookup(each.value, "credential_arn", null)
 }
 
 ################################################################################

--- a/main.tf
+++ b/main.tf
@@ -270,6 +270,7 @@ resource "aws_ecr_pull_through_cache_rule" "this" {
 
   ecr_repository_prefix = each.value.ecr_repository_prefix
   upstream_registry_url = each.value.upstream_registry_url
+  credential_arn        = try(each.value.credential_arn, null)
 }
 
 ################################################################################

--- a/main.tf
+++ b/main.tf
@@ -270,7 +270,7 @@ resource "aws_ecr_pull_through_cache_rule" "this" {
 
   ecr_repository_prefix = each.value.ecr_repository_prefix
   upstream_registry_url = each.value.upstream_registry_url
-  credential_arn        = try(each.value.credential_arn, null)
+  credential_arn        = coalesce(each.value.credential_arn, null)
 }
 
 ################################################################################

--- a/main.tf
+++ b/main.tf
@@ -270,7 +270,7 @@ resource "aws_ecr_pull_through_cache_rule" "this" {
 
   ecr_repository_prefix = each.value.ecr_repository_prefix
   upstream_registry_url = each.value.upstream_registry_url
-  credential_arn        = lookup(each.value, "credential_arn", null)
+  credential_arn        = try(each.value.credentials_arn, null)
 }
 
 ################################################################################

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.22"
+      version = ">= 5.40"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.40"
+      version = ">= 5.37"
     }
   }
 }


### PR DESCRIPTION
## Description

This feature PR adds the ability to pass a credentials_arn to the registry_pull_through_cache_rules variable, to allow to use this new field for pull through caches. 

## Motivation and Context

Since [November 2023](https://aws.amazon.com/about-aws/whats-new/2023/11/amazon-ecr-pull-through-cache-additional-upstream-registries/), ECR supports new upstream registries as pull through cache, including Dockerhub and GHCR. To use these new upstream registries, it's required to use credentials for the respective registries. AWS added a feature of providing a Secret Manager resource ARN to the ECR pull through cache rule to rely on this credentials. Along side this, the [terraform-provider-aws added the same capabilities ](https://github.com/hashicorp/terraform-provider-aws/issues/34466)to the aws_ecr_pull_through_cache_rule resource.

## Breaking Changes

This requires an update of the aws provider to >= 5.37 (previously >= 4.20). But there isn't any breaking change to update to this version.

## How Has This Been Tested?

- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects

We are using our fork to make sure that it works and added all the required docs and examples to this repo as well.

