### PR TITLE
feat: Add option to define credential arn for pull through caches

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ module "ecr_registry" {
     pub = {
       ecr_repository_prefix = "ecr-public"
       upstream_registry_url = "public.ecr.aws"
+    },
+    github = {
+        ecr_repository_prefix = "github"
+        upstream_registry_url = "ghrc.io"
+        credential_arn        = "arn:aws:secretsmanager:us-east-1:012345678901:secret:example"
+      }
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -270,6 +270,7 @@ resource "aws_ecr_pull_through_cache_rule" "this" {
 
   ecr_repository_prefix = each.value.ecr_repository_prefix
   upstream_registry_url = each.value.upstream_registry_url
+  credential_arn        = try(each.value.credential_arn, null)
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
Add option to define secret ARN for pull through caches. This is needed for docker.io for example.

## Motivation and Context
Support docker.io and ghrc.io as ECR pull through caches. 

## Breaking Changes
no

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
