### PR TITLE
fix: Correct typo `credentials_arn` -> `credential_arn`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.88.3
+    rev: v1.88.4
     hooks:
       - id: terraform_fmt
       - id: terraform_wrapper_module_for_each

--- a/main.tf
+++ b/main.tf
@@ -270,7 +270,7 @@ resource "aws_ecr_pull_through_cache_rule" "this" {
 
   ecr_repository_prefix = each.value.ecr_repository_prefix
   upstream_registry_url = each.value.upstream_registry_url
-  credential_arn        = try(each.value.credentials_arn, null)
+  credential_arn        = try(each.value.credential_arn, null)
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
- Correct typo `credentials_arn` -> `credential_arn`

## Motivation and Context
- Resolves #35 

## Breaking Changes
- No, it wasn't correct to begin with

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
