### PR TITLE
Fix case when Terraform breaks trying to create a Repository lifecycle policy  with empty argument

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 locals {
   create_private_repository = var.create && var.create_repository && var.repository_type == "private"
   create_public_repository  = var.create && var.create_repository && var.repository_type == "public"
+  create_lifecycle_policy   = var.create_lifecycle_policy && var.repository_lifecycle_policy != ""
 }
 
 data "aws_caller_identity" "current" {}
@@ -211,7 +212,7 @@ resource "aws_ecr_repository_policy" "this" {
 ################################################################################
 
 resource "aws_ecr_lifecycle_policy" "this" {
-  count = local.create_private_repository && var.create_lifecycle_policy ? 1 : 0
+  count = local.create_private_repository && local.create_lifecycle_policy ? 1 : 0
 
   repository = aws_ecr_repository.this[0].name
   policy     = var.repository_lifecycle_policy


### PR DESCRIPTION
## Description
This is a very simple PR to ~~change the default of "create_lifecycle_policy" variable to false~~ avoid breaking  during apply phase when both `var.create_lifecycle_policy` and `var.repository_lifecycle_policy` are left unset.

## Motivation and Context
If left unset both `var.create_lifecycle_policy` and `var.repository_lifecycle_policy`, Terraform will try to create the policy but using a empty string as argument, leading to the following error:

```
Error: creating ECR Lifecycle Policy (sos-rs-freetier-backend): operation error ECR: PutLifecyclePolicy, https response error StatusCode: 400, RequestID: c560fdf2-529f-4e79-837f-6ddf72eaed08, InvalidParameterException: Invalid parameter at 'lifecyclePolicyText' failed to satisfy constraint: 'Member must have length greater than or equal to 100'
│
│   with aws_ecr_lifecycle_policy.this[0],
│   on main.tf line 213, in resource "aws_ecr_lifecycle_policy" "this":
│  213: resource "aws_ecr_lifecycle_policy" "this" {
│
```

## Breaking Changes
There should be none.

## How Has This Been Tested?
I have tested locally with Terragrunt. It should work.

- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
