### PR TITLE
fix: use different sid for ecr and ecr-public resources

### DIFF
--- a/modules/repository-template/main.tf
+++ b/modules/repository-template/main.tf
@@ -121,7 +121,7 @@ data "aws_iam_policy_document" "repository" {
     for_each = length(var.repository_read_write_access_arns) > 0 ? [var.repository_read_write_access_arns] : []
 
     content {
-      sid = "ReadWrite"
+      sid = "ECRPublicReadWrite"
 
       principals {
         type        = "AWS"


### PR DESCRIPTION
## Description
Without this change, this produces an invalid Iam policy, since there is a duplicated sid. 

## Motivation and Context
As mentioned above, this MR now produces a valid IAM policy.

## Breaking Changes
No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ ] I have executed `pre-commit run -a` on my pull request
