### PR TITLE
fix: Remove Public ECR permissions from repository template permissions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.96.1
+    rev: v1.96.2
     hooks:
       - id: terraform_fmt
       - id: terraform_wrapper_module_for_each

--- a/modules/repository-template/main.tf
+++ b/modules/repository-template/main.tf
@@ -118,27 +118,6 @@ data "aws_iam_policy_document" "repository" {
   }
 
   dynamic "statement" {
-    for_each = length(var.repository_read_write_access_arns) > 0 ? [var.repository_read_write_access_arns] : []
-
-    content {
-      sid = "ReadWrite"
-
-      principals {
-        type        = "AWS"
-        identifiers = statement.value
-      }
-
-      actions = [
-        "ecr-public:BatchCheckLayerAvailability",
-        "ecr-public:CompleteLayerUpload",
-        "ecr-public:InitiateLayerUpload",
-        "ecr-public:PutImage",
-        "ecr-public:UploadLayerPart",
-      ]
-    }
-  }
-
-  dynamic "statement" {
     for_each = var.repository_policy_statements
 
     content {


### PR DESCRIPTION
## Description
- Remove Public ECR permissions from repository template permissions
  - Public ECR is only supported as a source, not a destination. Therefore, these permissions do not apply

## Motivation and Context
- Resolves #50

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
