### PR TITLE
chore(modules/repository-template): add prefix, upstream urls to outputs

### DIFF
--- a/modules/repository-template/README.md
+++ b/modules/repository-template/README.md
@@ -161,9 +161,12 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_create_pull_through_cache_rule"></a> [create\_pull\_through\_cache\_rule](#output\_create\_pull\_through\_cache\_rule) | Determines whether a pull through cache rule will be created |
 | <a name="output_iam_role_arn"></a> [iam\_role\_arn](#output\_iam\_role\_arn) | IAM role ARN |
 | <a name="output_iam_role_name"></a> [iam\_role\_name](#output\_iam\_role\_name) | IAM role name |
 | <a name="output_iam_role_unique_id"></a> [iam\_role\_unique\_id](#output\_iam\_role\_unique\_id) | Stable and unique string identifying the IAM role |
+| <a name="output_prefix"></a> [prefix](#output\_prefix) | The repository name prefix |
+| <a name="output_upstream_registry_url"></a> [upstream\_registry\_url](#output\_upstream\_registry\_url) | The registry URL of the upstream public registry to use as the source for the pull through cache rule |
 <!-- END_TF_DOCS -->
 
 ## License

--- a/modules/repository-template/outputs.tf
+++ b/modules/repository-template/outputs.tf
@@ -16,3 +16,18 @@ output "iam_role_unique_id" {
   description = "Stable and unique string identifying the IAM role"
   value       = try(aws_iam_role.this[0].unique_id, null)
 }
+
+output "prefix" {
+  description = "The repository name prefix"
+  value       = var.prefix
+}
+
+output "upstream_registry_url" {
+  description = "The registry URL of the upstream public registry to use as the source for the pull through cache rule"
+  value       = var.upstream_registry_url
+}
+
+output "create_pull_through_cache_rule" {
+  description = "Determines whether a pull through cache rule will be created"
+  value       = var.create && var.create_pull_through_cache_rule
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Add extra outputs from variables: `prefix`, `upstream_registry_url`, `create_pull_through_cache_rule`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We have Kyverno in several clusters with a mutate policy that changes some registries to ECR (for example `nginx:latest` to `12345678901.dkr.ecr.us-east-1.amazonaws.com/pull-through-docker/nginx:latest`).

Now we need to hard-code the pairs `<upstream_url>` -> `12345678901.dkr.ecr.us-east-1.amazonaws.com /<prefix>` in the Terragrunt input. It will be useful to set a dependency between pull through cache settings and Kyverno policies to escape hardcoding.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
