### PR TITLE
fix: Dynamic condition typo in repository_policy_statements logic

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -158,7 +158,7 @@ data "aws_iam_policy_document" "repository" {
       }
 
       dynamic "condition" {
-        for_each = statement.value.conditions != null ? statement.value.condition : []
+        for_each = statement.value.conditions != null ? statement.value.conditions : []
 
         content {
           test     = condition.value.test


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
fixes dynamic condition typo in repository_policy_statements logic that was introduced in version 3.0.0.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes the following terraform error:

> Error: Unsupported attribute
│
│   on .terraform/modules/example/main.tf line 161, in data "aws_iam_policy_document" "repository":
│  161:         for_each = statement.value.conditions != null ? statement.value.condition : []
│     ├────────────────
│     │ statement.value is object with 9 attributes
│
│ This object does not have an attribute named "condition".


## Breaking Changes
none
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
