### PR TITLE
Add validation for repository_name

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -36,6 +36,14 @@ variable "repository_name" {
   description = "The name of the repository"
   type        = string
   default     = ""
+
+  validation {
+    condition = can(regex(
+      "^(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*$",
+      var.repository_name_check
+    ))
+    error_message = "Invalid repository_name: must be lowercase and match ^(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*$"
+  }
 }
 
 variable "repository_image_tag_mutability" {


### PR DESCRIPTION
## Description
AWS validates repository names only during apply, a Terraform plan can incorrectly appear valid in the plan step.

This validation ensures that invalid repository names fail fast and early before any resources are created.
