### PR TITLE
feat: Add default ecr repository name

### DIFF
--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -26,7 +26,7 @@ module "wrapper" {
   repository_kms_key                               = try(each.value.repository_kms_key, var.defaults.repository_kms_key, null)
   repository_lambda_read_access_arns               = try(each.value.repository_lambda_read_access_arns, var.defaults.repository_lambda_read_access_arns, [])
   repository_lifecycle_policy                      = try(each.value.repository_lifecycle_policy, var.defaults.repository_lifecycle_policy, "")
-  repository_name                                  = try(each.value.repository_name, var.defaults.repository_name, "")
+  repository_name                                  = try(each.value.repository_name, var.defaults.repository_name, each.key)
   repository_policy                                = try(each.value.repository_policy, var.defaults.repository_policy, null)
   repository_policy_statements                     = try(each.value.repository_policy_statements, var.defaults.repository_policy_statements, null)
   repository_read_access_arns                      = try(each.value.repository_read_access_arns, var.defaults.repository_read_access_arns, [])


### PR DESCRIPTION
## Description
Use the wrapper's map key (each.key) as the default ECR repository name instead of an empty string when repository_name is not explicitly set.

## Motivation and Context
When using the wrappers module with multiple ECR repositories, users had to explicitly set repository_name for every entry even though the map key already represents a logical name. This change reduces boilerplate by falling back to each.key as a sensible default.

## Breaking Changes
No. This only affects cases where repository_name was previously omitted (which defaulted to ""). Existing configurations that explicitly set repository_name are unaffected.

## How Has This Been Tested?
[X] Deployed the wrappers module on a personal AWS account, confirmed that omitting repository_name correctly defaults to the map key and the ECR repository is created with the expected name.
